### PR TITLE
Update props.py: adding Robson's fertilities

### DIFF
--- a/flatlib/props.py
+++ b/flatlib/props.py
@@ -150,6 +150,22 @@ class sign:
         const.PISCES: const.SIGN_FERTILE
     }
     
+    # Fertilities according to V. Robson ('Sex and astrology', p. 112)
+    fertility_Robson = {
+        const.ARIES: const.SIGN_MODERATELY_STERILE,
+        const.TAURUS: const.SIGN_MODERATELY_FERTILE,
+        const.GEMINI: const.SIGN_STERILE,
+        const.CANCER: const.SIGN_FERTILE,
+        const.LEO: const.SIGN_STERILE,
+        const.VIRGO: const.SIGN_STERILE,
+        const.LIBRA: const.SIGN_MODERATELY_FERTILE,
+        const.SCORPIO: const.SIGN_FERTILE,
+        const.SAGITTARIUS: const.SIGN_MODERATELY_STERILE,
+        const.CAPRICORN: const.SIGN_MODERATELY_STERILE,
+        const.AQUARIUS: const.SIGN_MODERATELY_FERTILE,
+        const.PISCES: const.SIGN_FERTILE
+    }
+    
     # Sign number
     number = dict((sign, i+1) for (i, sign) in enumerate(_signs))
     


### PR DESCRIPTION
Fertility assessment in traditional sources is not comprehensive. I suggest adding classification based on 'Sex and astrology' (p. 112) - https://books.google.pl/books?id=0LUzs-w7iNgC&lpg=PA3&dq=inauthor%3A%22Vivian%20E.%20Robson%22&hl=pl&pg=PA112#v=onepage