### PR TITLE
Fixed typo "Retrogade".

### DIFF
--- a/flatlib/const.py
+++ b/flatlib/const.py
@@ -106,7 +106,7 @@ NO_PLANET = 'None'
 
 # Object movement
 DIRECT = 'Direct'
-RETROGRADE = 'Retrogade'
+RETROGRADE = 'Retrograde'
 STATIONARY = 'Stationary'
 
 # Mean daily motions


### PR DESCRIPTION
Minor fix but this typo was breaking code that expected the correct spelling "retrograde".